### PR TITLE
Added stub section creation + patching original import caller to call…

### DIFF
--- a/vmp-import-resolver/portable_executable/file_header.hpp
+++ b/vmp-import-resolver/portable_executable/file_header.hpp
@@ -4,9 +4,15 @@
 
 namespace portable_executable
 {
+    enum class machine_id_t : uint16_t
+    {
+        i386 = 0x014C,
+        amd64 = 0x8664,
+    };
+
     struct file_header_t
     {
-        std::uint16_t machine;
+        machine_id_t machine;
         std::uint16_t number_of_sections;
         std::uint32_t time_date_stamp;
         std::uint32_t pointer_to_symbol_table;

--- a/vmp-import-resolver/portable_executable/image.cpp
+++ b/vmp-import-resolver/portable_executable/image.cpp
@@ -26,7 +26,7 @@ portable_executable::section_header_t* portable_executable::image_t::find_sectio
 {
 	for (auto& section : this->sections())
 	{
-		if (section.to_str().find(name) != std::string::npos)
+		if (name == section.name)
 		{
 			return &section;
 		}

--- a/vmp-import-resolver/portable_executable/image.hpp
+++ b/vmp-import-resolver/portable_executable/image.hpp
@@ -66,8 +66,8 @@ namespace portable_executable
 
 			new_section_header->virtual_address = calculate_alignment(last_section_header->virtual_address + last_section_header->virtual_size, nt_headers->optional_header.section_alignment);
 			new_section_header->virtual_size = calculate_alignment(size + 5, nt_headers->optional_header.section_alignment);
-			new_section_header->pointer_to_raw_data = calculate_alignment(last_section_header->pointer_to_raw_data + last_section_header->size_of_raw_data, nt_headers->optional_header.file_alignment);
-			new_section_header->size_of_raw_data = calculate_alignment(size + 5, nt_headers->optional_header.file_alignment);
+			new_section_header->pointer_to_raw_data = new_section_header->virtual_address;
+			new_section_header->size_of_raw_data = new_section_header->virtual_size;
 			new_section_header->characteristics = { .flags = characteristics };
 
 			new_section_header->pointer_to_linenumbers = 0;


### PR DESCRIPTION
… stub + stub shellcode generation.

Added stub section creation + patching original import caller to call stub + stub shellcode generation. The dumped binary is extended by the size of the section (which is READ_EXECUTE). Shellcode is calculated + written in respectively for each required stub using asmjit.